### PR TITLE
Add detail show to items

### DIFF
--- a/plasma/ui/src/customized.css
+++ b/plasma/ui/src/customized.css
@@ -41,6 +41,31 @@ body {
   margin-left: auto;
   margin-right: auto;
 }
+
+hr.separator {
+  background-color: #c0c0c0;
+  height: 2px;
+}
+
+.detail-button {
+  background-color: #428bca;
+  border: none;
+  color: white;
+  padding: 6px 18px;
+  text-align: center;
+  display: inline-block;
+  border-radius: 4px;
+  float: right;
+}
+
+.details {
+  margin-top: 30px;
+  padding: 20px;
+  width: 100%;
+  border-radius: 4px;
+  background-color: #f8f8f8;
+}
+
 /*
  * Sidebar
  */

--- a/plasma/ui/src/js/components/home/ComposedNodeDetail.js
+++ b/plasma/ui/src/js/components/home/ComposedNodeDetail.js
@@ -1,0 +1,29 @@
+import React from "react";
+
+const ComposedNodeDetail = React.createClass({
+
+  render() {
+    var node = this.props.node;
+    return (
+      <div>
+        Node Name: {node.Name}<br/>
+        Description: {node.Description}<br/>
+        System Type: {node.SystemType}<br/>
+        Model: {node.Model}<br/>
+        Serial Number: {node.SerialNumber}<br/>
+        UUID: {node.UUID}<br/>
+        BIOS Version: {node.BiosVersion}<br/>
+        State: {node.Status.State}<br/>
+        Health: {node.Status.Health}<br/>
+        Processor Count: {node.Processors.Count}<br/>
+        Processor Model: {node.Processors.Model}<br/>
+        Total Memory: {node.Memory.TotalSystemMemoryGiB} GiB<br/>
+        Composed Node State: {node.ComposedNodeState}<br/>
+        Boot Source Override Enabled: {node.Boot.BootSourceOverrideEnabled}<br/>
+        Boot Source Override Target: {node.Boot.BootSourceOverrideTarget}
+      </div>
+    );
+  }
+});
+
+export default ComposedNodeDetail

--- a/plasma/ui/src/js/components/home/ComposedNodeList.js
+++ b/plasma/ui/src/js/components/home/ComposedNodeList.js
@@ -4,27 +4,27 @@ import ItemList from "./ItemList";
 var config = require('../../../config.js');
 var util = require('./util.js');
 
-const Racks = React.createClass({
+const ComposedNodeList = React.createClass({
 
   getInitialState() {
-    return {racks: []};
+    return {composedNodes: []};
   },
 
   componentWillMount() {
-    this.getRacks();
+    this.getComposedNodes();
   },
 
-  getRacks() {
-    var url = config.url + '/redfish/v1/Chassis';
+  getComposedNodes() {
+    var composedNodes;
+    var url = config.url + '/redfish/v1/Nodes';
     $.ajax({
       url: url,
       type: 'GET',
       dataType: 'json',
       cache: false,
       success: function(resp) {
-        var chassis = util.listMembers(resp)
-        var racks = util.filterChassis(chassis, 'Rack');
-        this.setData(racks);
+        composedNodes = util.listMembers(resp);
+        this.setData(composedNodes);
       }.bind(this),
       error: function(xhr, status, err) {
         console.error(url, status, err.toString());
@@ -32,15 +32,15 @@ const Racks = React.createClass({
     });
   },
 
-  setData(racks) {
-    this.setState({racks: racks});
+  setData(composedNodes) {
+    this.setState({composedNodes: composedNodes});
   },
 
   render() {
     return (
-      <ItemList items={this.state.racks} header="RACKS" />
+      <ItemList onShowDetail={this.props.onShowDetail} items={this.state.composedNodes} header="COMPOSED NODES" />
     );
   }
 });
 
-export default Racks
+export default ComposedNodeList

--- a/plasma/ui/src/js/components/home/Home.js
+++ b/plasma/ui/src/js/components/home/Home.js
@@ -1,13 +1,46 @@
 import React from "react";
 
-import Pods from "./Pods";
-import Racks from "./Racks";
-import Systems from "./Systems";
-import ComposedNodes from "./ComposedNodes";
+import PodList from "./PodList";
+import PodDetail from "./PodDetail";
+import RackList from "./RackList";
+import RackDetail from "./RackDetail";
+import SystemList from "./SystemList";
+import SystemDetail from "./SystemDetail";
+import ComposedNodeList from "./ComposedNodeList";
+import ComposedNodeDetail from "./ComposedNodeDetail";
 
-export default class Home extends React.Component {
+const Home = React.createClass({
 
-  render() {
+  getInitialState: function() {
+    return {
+      detail: "",
+      detailDisplay: "none"
+    };
+  },
+
+  handleShowDetail: function(item, itemType) {
+    if (itemType == "PODS") {
+      this.setState({detail: <PodDetail pod={item} />});
+    } else if (itemType == "RACKS") {
+      this.setState({detail: <RackDetail rack={item} />});
+    } else if (itemType == "SYSTEMS") {
+      this.setState({detail: <SystemDetail system={item} />});
+    } else {
+      this.setState({detail: <ComposedNodeDetail node={item} />});
+    }
+    this.setState({
+      detailDisplay: "inline-block"
+    });
+  },
+
+  handleHideDetail: function() {
+    this.setState({
+      detail: "",
+      detailDisplay: "none"
+    });
+  },
+
+  render: function() {
     return (
       <div>
         <div class="jumbotron">
@@ -30,15 +63,23 @@ export default class Home extends React.Component {
             </div>
             <div class="col-sm-9 col-md-10 main">
               <div class="tab-content">
-                <div role="tabpanel" class="tab-pane active" id="pods"><Pods /></div>
-                <div role="tabpanel" class="tab-pane" id="racks"><Racks /></div>
-                <div role="tabpanel" class="tab-pane" id="systems"><Systems /></div>
-                <div role="tabpanel" class="tab-pane" id="composednodes"><ComposedNodes /></div>
+                <div role="tabpanel" class="tab-pane active" id="pods"><PodList onShowDetail={this.handleShowDetail} /></div>
+                <div role="tabpanel" class="tab-pane" id="racks"><RackList onShowDetail={this.handleShowDetail} /></div>
+                <div role="tabpanel" class="tab-pane" id="systems"><SystemList onShowDetail={this.handleShowDetail} /></div>
+                <div role="tabpanel" class="tab-pane" id="composednodes"><ComposedNodeList onShowDetail={this.handleShowDetail} /></div>
               </div>
             </div>
           </div>
         </div>
+
+        <div class="details" style={{display: this.state.detailDisplay}}>
+          {this.state.detail}
+          <input type="button" class="detail-button" onClick={() => this.handleHideDetail()} value="Hide Details" />
+        </div>
+
       </div>
     );
   }
-}
+});
+
+export default Home

--- a/plasma/ui/src/js/components/home/ItemList.js
+++ b/plasma/ui/src/js/components/home/ItemList.js
@@ -1,22 +1,30 @@
 import React from "react";
 
-export default class ItemList extends React.Component {
-  renderItems() {
+var util = require('./util.js');
+
+const ItemList = React.createClass({
+
+  renderList: function() {
     return this.props.items.map((item, i) =>
       <div class="item" key={i}>
-        {item.Name} <br />
+        {item.Name}
+        <input type="button" class="detail-button" onClick={() => this.props.onShowDetail(item, this.props.header)} value="Show" />
+        <br />
         {item.Description}
+        <hr class="separator"/>
       </div>
     );
-  }
+  },
 
-  render() {
+  render: function() {
     return (
       <div>
-        {this.renderItems()}
+        {this.renderList()}
       </div>
     );
-  }
-}
+  },
+});
 
 ItemList.defaultProps = { items: [], header: ""};
+
+export default ItemList;

--- a/plasma/ui/src/js/components/home/PodDetail.js
+++ b/plasma/ui/src/js/components/home/PodDetail.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+const PodDetail = React.createClass({
+
+  render() {
+    var pod = this.props.pod;
+    return (
+      <div>
+        Pod Name: {pod.Name}<br/>
+        Description: {pod.Description}<br/>
+        State: {pod.Status.State}<br/>
+        Health: {pod.Status.Health}
+      </div>
+    );
+  }
+});
+
+export default PodDetail

--- a/plasma/ui/src/js/components/home/PodList.js
+++ b/plasma/ui/src/js/components/home/PodList.js
@@ -4,7 +4,7 @@ import ItemList from "./ItemList";
 var config = require('../../../config.js');
 var util = require('./util.js');
 
-const Pods = React.createClass({
+const PodList = React.createClass({
 
   getInitialState() {
     return {pods: []};
@@ -38,9 +38,9 @@ const Pods = React.createClass({
 
   render() {
     return (
-      <ItemList items={this.state.pods} header="PODS" />
+      <ItemList onShowDetail={this.props.onShowDetail} items={this.state.pods} header="PODS" />
     );
   }
 });
 
-export default Pods
+export default PodList

--- a/plasma/ui/src/js/components/home/RackDetail.js
+++ b/plasma/ui/src/js/components/home/RackDetail.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+const RackDetail = React.createClass({
+
+  render() {
+    var rack = this.props.rack;
+    return (
+      <div>
+        Rack Name: {rack.Name}<br/>
+        Description: {rack.Description}<br/>
+        Manufacturer: {rack.Manufacturer}<br/>
+        Serial Number: {rack.SerialNumber}<br/>
+      </div>
+    );
+  }
+});
+
+export default RackDetail

--- a/plasma/ui/src/js/components/home/RackList.js
+++ b/plasma/ui/src/js/components/home/RackList.js
@@ -4,27 +4,27 @@ import ItemList from "./ItemList";
 var config = require('../../../config.js');
 var util = require('./util.js');
 
-const Systems = React.createClass({
+const RackList = React.createClass({
 
   getInitialState() {
-    return {systems: []};
+    return {racks: []};
   },
 
   componentWillMount() {
-    this.getSystems();
+    this.getRacks();
   },
 
-  getSystems() {
-    var systems;
-    var url = config.url + '/redfish/v1/Systems';
+  getRacks() {
+    var url = config.url + '/redfish/v1/Chassis';
     $.ajax({
       url: url,
       type: 'GET',
       dataType: 'json',
       cache: false,
       success: function(resp) {
-        systems = util.listMembers(resp);
-        this.setData(systems);
+        var chassis = util.listMembers(resp)
+        var racks = util.filterChassis(chassis, 'Rack');
+        this.setData(racks);
       }.bind(this),
       error: function(xhr, status, err) {
         console.error(url, status, err.toString());
@@ -32,15 +32,15 @@ const Systems = React.createClass({
     });
   },
 
-  setData(systems) {
-    this.setState({systems: systems});
+  setData(racks) {
+    this.setState({racks: racks});
   },
 
   render() {
     return (
-      <ItemList items={this.state.systems} header="SYSTEMS" />
+      <ItemList onShowDetail={this.props.onShowDetail} items={this.state.racks} header="RACKS" />
     );
   }
 });
 
-export default Systems
+export default RackList

--- a/plasma/ui/src/js/components/home/SystemDetail.js
+++ b/plasma/ui/src/js/components/home/SystemDetail.js
@@ -1,0 +1,25 @@
+import React from "react";
+
+const SystemDetail = React.createClass({
+
+  render() {
+    var system = this.props.system;
+    return (
+      <div>
+        System Name: {system.Name}<br/>
+        Description: {system.Description}<br/>
+        System Type: {system.SystemType}<br/>
+        UUID: {system.UUID}<br/>
+        Host Name: {system.HostName}<br/>
+        State: {system.Status.State}<br/>
+        Health: {system.Status.Health}<br/>
+        Power State: {system.PowerState}<br/>
+        BIOS Version: {system.BiosVersion}<br/>
+        Processor Count: {system.ProcessorSummary.Count}<br/>
+        System Memory: {system.MemorySummary.TotalSystemMemoryGiB} GiB
+      </div>
+    );
+  }
+});
+
+export default SystemDetail

--- a/plasma/ui/src/js/components/home/SystemList.js
+++ b/plasma/ui/src/js/components/home/SystemList.js
@@ -4,27 +4,27 @@ import ItemList from "./ItemList";
 var config = require('../../../config.js');
 var util = require('./util.js');
 
-const ComposedNodes = React.createClass({
+const SystemList = React.createClass({
 
   getInitialState() {
-    return {composedNodes: []};
+    return {systems: []};
   },
 
   componentWillMount() {
-    this.getComposedNodes();
+    this.getSystems();
   },
 
-  getComposedNodes() {
-    var composedNodes;
-    var url = config.url + '/redfish/v1/Nodes';
+  getSystems() {
+    var systems;
+    var url = config.url + '/redfish/v1/Systems';
     $.ajax({
       url: url,
       type: 'GET',
       dataType: 'json',
       cache: false,
       success: function(resp) {
-        composedNodes = util.listMembers(resp);
-        this.setData(composedNodes);
+        systems = util.listMembers(resp);
+        this.setData(systems);
       }.bind(this),
       error: function(xhr, status, err) {
         console.error(url, status, err.toString());
@@ -32,15 +32,15 @@ const ComposedNodes = React.createClass({
     });
   },
 
-  setData(composedNodes) {
-    this.setState({composedNodes: composedNodes});
+  setData(systems) {
+    this.setState({systems: systems});
   },
 
   render() {
     return (
-      <ItemList items={this.state.composedNodes} header="COMPOSED NODES" />
+      <ItemList onShowDetail={this.props.onShowDetail} items={this.state.systems} header="SYSTEMS" />
     );
   }
 });
 
-export default ComposedNodes
+export default SystemList


### PR DESCRIPTION
This commit adds a "Show" button next to items in the lists
of Pods, Racks, Systems and Nodes. When Pressed it will display
details about the specified item.

It also changes files like 'Pods.js' to 'PodList.js' to differentiate between
the list view and the detail view.

Signed-off-by: Nate Potter nathaniel.potter@intel.com
