### PR TITLE
Append authorization header into ajax call

### DIFF
--- a/plasma/ui/src/js/util.js
+++ b/plasma/ui/src/js/util.js
@@ -1,5 +1,12 @@
 var config = require('./config.js');
 
+$.ajaxSetup({
+    beforeSend: function (xhr)
+    {
+       xhr.setRequestHeader('Authorization', 'Basic YWRtaW46YWRtaW4=');
+    }
+});
+
 exports.listMembers = function(jsonContent) {
   var returnMembers = [];
   var members = jsonContent['Members'];


### PR DESCRIPTION
Pod manager api requires basic authorization. Previous solution
depends on a apache reserve proxy service to handle it. So append
this header to prepare get rid of apache proxy.

Change-Id: I4af980059721f96f0b5b9f00607733e28385bf4f
Signed-off-by: Lin Yang lin.a.yang@intel.com
