### PR TITLE
use sudo to start services prevending *stop: Unknown job: valence-controller*

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,9 +52,9 @@ Valence installation
 
  8. Start api and controller services
     
-    ``$ service valence-api start`` 
+    ``$ sudo service valence-api start`` 
 
-    ``$ service valence-controller start``
+    ``$ sudo service valence-controller start``
 
  9. Logs are located at /var/logs/valence/
 


### PR DESCRIPTION
In Ubuntu 14.04 if use:
`service valence-controller start`
There will be error:
`start: Unknown job: valence-controller`
So, maybe `service valence-controller start` is better.
